### PR TITLE
Add method listing endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,14 @@ For WordPress-specific methods (like managing posts), you need to provide:
 
 The server supports both WordPress and WooCommerce API methods. Here's a list of available methods grouped by category:
 
+### Utility
+
+| Method | Description |
+|--------|-------------|
+| `list_available_methods` | Returns an array of all available method names |
+
+This method responds with a simple array of strings containing every supported RPC method.
+
 ### WordPress Content Management
 
 These methods require WordPress username/password credentials and are independent of the WooCommerce API.

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,11 +49,160 @@ const DEFAULT_PASSWORD = process.env.WORDPRESS_PASSWORD || "";
 const DEFAULT_CONSUMER_KEY = process.env.WOOCOMMERCE_CONSUMER_KEY || "";
 const DEFAULT_CONSUMER_SECRET = process.env.WOOCOMMERCE_CONSUMER_SECRET || "";
 
+// WordPress JSON-RPC methods
+export const wpMethods = [
+  "create_post",
+  "get_posts",
+  "update_post",
+  "get_post_meta",
+  "update_post_meta",
+  "create_post_meta",
+  "delete_post_meta",
+];
+
+// WooCommerce JSON-RPC methods
+export const wooMethods = [
+  "get_products",
+  "get_product",
+  "create_product",
+  "update_product",
+  "delete_product",
+  "get_orders",
+  "get_order",
+  "create_order",
+  "update_order",
+  "delete_order",
+  "get_customers",
+  "get_customer",
+  "create_customer",
+  "update_customer",
+  "delete_customer",
+  "get_sales_report",
+  "get_products_report",
+  "get_orders_report",
+  "get_categories_report",
+  "get_customers_report",
+  "get_stock_report",
+  "get_coupons_report",
+  "get_taxes_report",
+  // Shipping methods
+  "get_shipping_zones",
+  "get_shipping_zone",
+  "create_shipping_zone",
+  "update_shipping_zone",
+  "delete_shipping_zone",
+  "get_shipping_methods",
+  "get_shipping_zone_methods",
+  "create_shipping_zone_method",
+  "update_shipping_zone_method",
+  "delete_shipping_zone_method",
+  "get_shipping_zone_locations",
+  "update_shipping_zone_locations",
+  // Tax settings
+  "get_tax_classes",
+  "create_tax_class",
+  "delete_tax_class",
+  "get_tax_rates",
+  "get_tax_rate",
+  "create_tax_rate",
+  "update_tax_rate",
+  "delete_tax_rate",
+  // Discount/Coupon settings
+  "get_coupons",
+  "get_coupon",
+  "create_coupon",
+  "update_coupon",
+  "delete_coupon",
+  // Order notes
+  "get_order_notes",
+  "get_order_note",
+  "create_order_note",
+  "delete_order_note",
+  // Order refunds
+  "get_order_refunds",
+  "get_order_refund",
+  "create_order_refund",
+  "delete_order_refund",
+  // Product variations
+  "get_product_variations",
+  "get_product_variation",
+  "create_product_variation",
+  "update_product_variation",
+  "delete_product_variation",
+  // Product attributes
+  "get_product_attributes",
+  "get_product_attribute",
+  "create_product_attribute",
+  "update_product_attribute",
+  "delete_product_attribute",
+  // Product attribute terms
+  "get_attribute_terms",
+  "get_attribute_term",
+  "create_attribute_term",
+  "update_attribute_term",
+  "delete_attribute_term",
+  // Product categories
+  "get_product_categories",
+  "get_product_category",
+  "create_product_category",
+  "update_product_category",
+  "delete_product_category",
+  // Product tags
+  "get_product_tags",
+  "get_product_tag",
+  "create_product_tag",
+  "update_product_tag",
+  "delete_product_tag",
+  // Product reviews
+  "get_product_reviews",
+  "get_product_review",
+  "create_product_review",
+  "update_product_review",
+  "delete_product_review",
+  // Payment gateways
+  "get_payment_gateways",
+  "get_payment_gateway",
+  "update_payment_gateway",
+  // Settings
+  "get_settings",
+  "get_setting_options",
+  "update_setting_option",
+  // System status
+  "get_system_status",
+  "get_system_status_tools",
+  "run_system_status_tool",
+  // Data
+  "get_data",
+  "get_continents",
+  "get_countries",
+  "get_currencies",
+  "get_current_currency",
+  // Meta data operations for products
+  "get_product_meta",
+  "update_product_meta",
+  "create_product_meta",
+  "delete_product_meta",
+  // Meta data operations for orders
+  "get_order_meta",
+  "update_order_meta",
+  "create_order_meta",
+  "delete_order_meta",
+  // Meta data operations for customers
+  "get_customer_meta",
+  "update_customer_meta",
+  "create_customer_meta",
+  "delete_customer_meta",
+];
+
 async function handleWooCommerceRequest(
   method: string,
   params: any
 ): Promise<any> {
   try {
+    if (method === "list_available_methods") {
+      return [...wpMethods, ...wooMethods];
+    }
+
     const siteUrl = params.siteUrl || DEFAULT_SITE_URL;
     const username = params.username || DEFAULT_USERNAME;
     const password = params.password || DEFAULT_PASSWORD;
@@ -65,151 +214,6 @@ async function handleWooCommerceRequest(
         "WordPress site URL not provided in environment variables or request parameters"
       );
     }
-
-    // For standard WordPress API endpoints
-    const wpMethods = [
-      "create_post",
-      "get_posts",
-      "update_post",
-      "get_post_meta",
-      "update_post_meta",
-      "create_post_meta",
-      "delete_post_meta",
-    ];
-
-    // For WooCommerce API endpoints
-    const wooMethods = [
-      "get_products",
-      "get_product",
-      "create_product",
-      "update_product",
-      "delete_product",
-      "get_orders",
-      "get_order",
-      "create_order",
-      "update_order",
-      "delete_order",
-      "get_customers",
-      "get_customer",
-      "create_customer",
-      "update_customer",
-      "delete_customer",
-      "get_sales_report",
-      "get_products_report",
-      "get_orders_report",
-      "get_categories_report",
-      "get_customers_report",
-      "get_stock_report",
-      "get_coupons_report",
-      "get_taxes_report",
-      // Shipping methods
-      "get_shipping_zones",
-      "get_shipping_zone",
-      "create_shipping_zone",
-      "update_shipping_zone",
-      "delete_shipping_zone",
-      "get_shipping_methods",
-      "get_shipping_zone_methods",
-      "create_shipping_zone_method",
-      "update_shipping_zone_method",
-      "delete_shipping_zone_method",
-      "get_shipping_zone_locations",
-      "update_shipping_zone_locations",
-      // Tax settings
-      "get_tax_classes",
-      "create_tax_class",
-      "delete_tax_class",
-      "get_tax_rates",
-      "get_tax_rate",
-      "create_tax_rate",
-      "update_tax_rate",
-      "delete_tax_rate",
-      // Discount/Coupon settings
-      "get_coupons",
-      "get_coupon",
-      "create_coupon",
-      "update_coupon",
-      "delete_coupon",
-      // Order notes
-      "get_order_notes",
-      "get_order_note",
-      "create_order_note",
-      "delete_order_note",
-      // Order refunds
-      "get_order_refunds",
-      "get_order_refund",
-      "create_order_refund",
-      "delete_order_refund",
-      // Product variations
-      "get_product_variations",
-      "get_product_variation",
-      "create_product_variation",
-      "update_product_variation",
-      "delete_product_variation",
-      // Product attributes
-      "get_product_attributes",
-      "get_product_attribute",
-      "create_product_attribute",
-      "update_product_attribute",
-      "delete_product_attribute",
-      // Product attribute terms
-      "get_attribute_terms",
-      "get_attribute_term",
-      "create_attribute_term",
-      "update_attribute_term",
-      "delete_attribute_term",
-      // Product categories
-      "get_product_categories",
-      "get_product_category",
-      "create_product_category",
-      "update_product_category",
-      "delete_product_category",
-      // Product tags
-      "get_product_tags",
-      "get_product_tag",
-      "create_product_tag",
-      "update_product_tag",
-      "delete_product_tag",
-      // Product reviews
-      "get_product_reviews",
-      "get_product_review",
-      "create_product_review",
-      "update_product_review",
-      "delete_product_review",
-      // Payment gateways
-      "get_payment_gateways",
-      "get_payment_gateway",
-      "update_payment_gateway",
-      // Settings
-      "get_settings",
-      "get_setting_options",
-      "update_setting_option",
-      // System status
-      "get_system_status",
-      "get_system_status_tools",
-      "run_system_status_tool",
-      // Data
-      "get_data",
-      "get_continents",
-      "get_countries",
-      "get_currencies",
-      "get_current_currency",
-      // Meta data operations for products
-      "get_product_meta",
-      "update_product_meta",
-      "create_product_meta",
-      "delete_product_meta",
-      // Meta data operations for orders
-      "get_order_meta",
-      "update_order_meta",
-      "create_order_meta",
-      "delete_order_meta",
-      // Meta data operations for customers
-      "get_customer_meta",
-      "update_customer_meta",
-      "create_customer_meta",
-      "delete_customer_meta",
-    ];
 
     // Create WordPress REST API client
     let client;
@@ -253,6 +257,9 @@ async function handleWooCommerceRequest(
 
     // Handle WordPress API methods
     switch (method) {
+      case "list_available_methods":
+        return [...wpMethods, ...wooMethods];
+
       case "create_post":
         if (!params.title || !params.content) {
           throw new Error("Title and content are required for creating a post");


### PR DESCRIPTION
## Summary
- expose wpMethods and wooMethods constants
- add `list_available_methods` JSON-RPC method
- document the new method in README
- rebuild TypeScript output

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688118b0a78083318dcb65fbc2a8c6eb